### PR TITLE
Fixes for emacs 25.2.2

### DIFF
--- a/flymake-cursor.el
+++ b/flymake-cursor.el
@@ -143,7 +143,7 @@ the mode directly."
   "pyflake is flakey if it has compile problems, this adjusts the
 message to display, so there is one ;)"
   (cond ((not (or (eq major-mode 'Python) (eq major-mode 'python-mode) t)))
-        ((boundp 'flymake-diagnostic-text)
+        ((fboundp 'flymake-diagnostic-text)
          (let ((msg (flymake-diagnostic-text error)))
            (if (null msg) msg (format "compile error, problem on line %s" msg))))
         (t

--- a/flymake-cursor.el
+++ b/flymake-cursor.el
@@ -134,7 +134,7 @@ the mode directly."
 (defun flymake-cursor-get-errors ()
   (cond ((boundp 'flymake-err-info)  ; emacs < 26
          (let ((lineno (line-number-at-pos)))
-           (err-info (car (flymake-find-err-info flymake-err-info lineno)))))
+           (car (flymake-find-err-info flymake-err-info lineno))))
         ((and (fboundp 'flymake-diagnostic-text)
               (fboundp 'flymake-diagnostics))  ; emacs >= 26
          (flymake-diagnostics (point)))))
@@ -143,12 +143,11 @@ the mode directly."
   "pyflake is flakey if it has compile problems, this adjusts the
 message to display, so there is one ;)"
   (cond ((not (or (eq major-mode 'Python) (eq major-mode 'python-mode) t)))
-        ((boundp 'flymake-ler-file)
-         (let ((msg (flymake-ler-file error)))
+        ((boundp 'flymake-diagnostic-text)
+         (let ((msg (flymake-diagnostic-text error)))
            (if (null msg) msg (format "compile error, problem on line %s" msg))))
         (t
-         (let ((msg (flymake-diagnostic-text error)))
-           (if (null msg) msg (format "compile error, problem on line %s" msg))))))
+         (flymake-ler-text error))))
 
 (defun flymake-cursor-safe-to-display ()
   "Returns t if Flymake Cursor is safe to display to the minibuffer or nil if


### PR DESCRIPTION
* fixes improper use of flymake-err-find-info
* pyflakes function should check for 'flymake-diagnostic-text, not 'flymake-ler-file, which is defined but not 'boundp'